### PR TITLE
fix: links cannot be left undefined

### DIFF
--- a/api/scraper.py
+++ b/api/scraper.py
@@ -473,6 +473,7 @@ class Scraper:
             icon=img,
             title=title,
             about=info or None,
+            links=await self.fetch_links(site, id, group_type),
         )
         
         


### PR DESCRIPTION
Kept crashing when I was trying to get teh main data, so this is a bodge to fix that

The other option would eb to remove teh links from it entirely and use teh seperate endpoint for them.